### PR TITLE
Fix memory leak due to DNS failure

### DIFF
--- a/httpclient.c
+++ b/httpclient.c
@@ -356,6 +356,11 @@ static void ICACHE_FLASH_ATTR dns_callback(const char * hostname, ip_addr_t * ad
 		if (req->user_callback != NULL) {
 			req->user_callback("", -1, "", 0);
 		}
+		os_free(req->buffer);
+		os_free(req->post_data);
+		os_free(req->headers);
+		os_free(req->path);
+		os_free(req->hostname);
 		os_free(req);
 	}
 	else {


### PR DESCRIPTION
Some buffers are created in http_raw_request() and are freed in the sunny day code path but not when there is a DNS failure.
